### PR TITLE
Mass renaming and adding of placeholder tokens for contents that either match no token or encompass a child context.

### DIFF
--- a/YoggTree/Tests/BasicTests/Common/TestTokens.cs
+++ b/YoggTree/Tests/BasicTests/Common/TestTokens.cs
@@ -27,17 +27,25 @@ namespace YoggTreeTest.Common
 
         public static TestTokenInstance HorizontalWhitespace(string whitespace)
         {
-            return new TestTokenInstance(StandardTokens.WhitespaceHorizontal, whitespace);
+            return new TestTokenInstance(StandardTokens.WhitespaceHorizontal, whitespace, TokenInstanceType.RegexResult);
         }
 
         public static TestTokenInstance VerticalWhitespace(string whitespace)
         {
-            return new TestTokenInstance(StandardTokens.WhitespaceVertical, whitespace);
+            return new TestTokenInstance(StandardTokens.WhitespaceVertical, whitespace, TokenInstanceType.RegexResult);
         }
 
         public static TestTokenInstance TextContent(string content)
         {
-            return new TestTokenInstance(StandardTokens.TextContent, content);
+            return new TestTokenInstance(StandardTokens.TextContent, content, TokenInstanceType.TextPlaceholder);
+        }
+
+        public static TestTokenInstance ChildContext(string contextContent, TestContextInstance childContext)
+        {
+            return new TestTokenInstance(StandardTokens.Empty, contextContent, TokenInstanceType.ContextPlaceholder)
+            {
+                TestContextInstance = childContext
+            };
         }
     }
 }

--- a/YoggTree/Tests/BasicTests/Theories/Theory_Basic_Parse.cs
+++ b/YoggTree/Tests/BasicTests/Theories/Theory_Basic_Parse.cs
@@ -101,27 +101,28 @@ namespace BasicTests.Theories
         {
             string contentToParse = "[]";
             TestContext testContext = new TestContext();
+            TestContextInstance childInstance = new TestContextInstance(testContext)
+            {
+                Contents = "[]",
+                Depth = 1,
+                Tokens = new List<TestTokenInstance>()
+                {
+                    TestTokens.OpenBracket,
+                    TestTokens.CloseBracket
+                }
+            };
+
             TestContextInstance expected = new TestContextInstance(testContext)
             {
                 Contents = contentToParse,
                 Depth = 0,
                 Tokens = new List<TestTokenInstance>()
                 {
-                    TestTokens.OpenBracket , 
-                    TestTokens.CloseBracket
+                    TestTokens.ChildContext("[]", childInstance)
                 },
                 ChildContexts = new List<TestContextInstance>()
                 {
-                    new TestContextInstance(testContext)
-                    {
-                        Contents = "[]",
-                        Depth = 1,
-                        Tokens = new List<TestTokenInstance>()
-                        {
-                            TestTokens.OpenBracket, 
-                            TestTokens.CloseBracket
-                        }
-                    }
+                    childInstance
                 }
             };
 
@@ -134,41 +135,44 @@ namespace BasicTests.Theories
 
             args.Add(YoggTreeTestHelper.ToObjArray(testArgs));
 
+            /*****************************************************************************************/
+
             contentToParse = "[]{}";
             testContext = new TestContext();
+            TestContextInstance child1 = new TestContextInstance(testContext)
+            {
+                Contents = "[]",
+                Depth = 1,
+                Tokens = new List<TestTokenInstance>()
+                {
+                    TestTokens.OpenBracket,
+                    TestTokens.CloseBracket
+                }
+            };
+
+            TestContextInstance child2 = new TestContextInstance(testContext)
+            {
+                Contents = "{}",
+                Depth = 1,
+                Tokens = new List<TestTokenInstance>()
+                {
+                    TestTokens.OpenBrace,
+                    TestTokens.CloseBrace,
+                }
+            };
+
             expected = new TestContextInstance(testContext)
             {
                 Contents = contentToParse,
                 Depth = 0,
                 Tokens = new List<TestTokenInstance>()
                 {
-                    TestTokens.OpenBracket,
-                    TestTokens.CloseBracket,
-                    TestTokens.OpenBrace,
-                    TestTokens.CloseBrace
+                    TestTokens.ChildContext("[]", child1),
+                    TestTokens.ChildContext("{}", child2)
                 },
                 ChildContexts = new List<TestContextInstance>()
                 {
-                    new TestContextInstance(testContext)
-                    {
-                        Contents = "[]",
-                        Depth = 1,
-                        Tokens = new List<TestTokenInstance>()
-                        {
-                            TestTokens.OpenBracket,
-                            TestTokens.CloseBracket
-                        }
-                    },
-                    new TestContextInstance(testContext)
-                    {
-                        Contents = "{}",
-                        Depth = 1,
-                        Tokens = new List<TestTokenInstance>()
-                        {
-                            TestTokens.OpenBrace,
-                            TestTokens.CloseBrace,
-                        }
-                    }
+                    child1, child2
                 }
             };
 
@@ -181,44 +185,49 @@ namespace BasicTests.Theories
 
             args.Add(YoggTreeTestHelper.ToObjArray(testArgs));
 
+            /*****************************************************************************************/
+
             contentToParse = "[[]]";
             testContext = new TestContext();
+
+            var childSub1 = new TestContextInstance(testContext)
+            {
+                Contents = "[]",
+                Depth = 2,
+                Tokens = new List<TestTokenInstance>()
+                {
+                    TestTokens.OpenBracket,
+                    TestTokens.CloseBracket,
+                }
+            };
+
+            child1 = new TestContextInstance(testContext)
+            {
+                Contents = "[[]]",
+                Depth = 1,
+                Tokens = new List<TestTokenInstance>()
+                {
+                    TestTokens.OpenBracket,
+                    TestTokens.ChildContext("[]", childSub1),
+                    TestTokens.CloseBracket
+                },
+                ChildContexts = new List<TestContextInstance>()
+                {
+                    childSub1     
+                }
+            };
+
             expected = new TestContextInstance(testContext)
             {
                 Contents = contentToParse,
                 Depth = 0,
                 Tokens = new List<TestTokenInstance>()
                 {
-                    TestTokens.OpenBracket,
-                    TestTokens.CloseBracket
+                    TestTokens.ChildContext("[[]]", child1),
                 },
                 ChildContexts = new List<TestContextInstance>()
                 {
-                    new TestContextInstance(testContext)
-                    {
-                        Contents = "[[]]",
-                        Depth = 1,
-                        Tokens = new List<TestTokenInstance>()
-                        {
-                            TestTokens.OpenBracket,
-                            TestTokens.OpenBracket,
-                            TestTokens.CloseBracket,
-                            TestTokens.CloseBracket
-                        },
-                        ChildContexts= new List<TestContextInstance>()
-                        {
-                            new TestContextInstance(testContext)
-                            {
-                                Contents = "[]",
-                                Depth = 2,
-                                Tokens = new List<TestTokenInstance>()
-                                {
-                                    TestTokens.OpenBracket,
-                                    TestTokens.CloseBracket
-                                }
-                            }
-                        }
-                    }                    
+                    child1   
                 }
             };
 
@@ -237,89 +246,96 @@ namespace BasicTests.Theories
             string contentToParse = "[{[[()]]}]";
             TestContext testContext = new TestContext();
 
-            TestContextInstance expected = new TestContextInstance(testContext)
+            var child_1_5 = new TestContextInstance(testContext)
+            {
+                Contents = "()",
+                Depth = 5,
+                Tokens = new List<TestTokenInstance>()
+                {
+                    TestTokens.OpenParens,
+                    TestTokens.CloseParens
+                }
+            };
+
+            var child_1_4 = new TestContextInstance(testContext)
+            {
+                Contents = "[()]",
+                Depth = 4,
+                Tokens = new List<TestTokenInstance>()
+                {
+                    TestTokens.OpenBracket,
+                    TestTokens.ChildContext("()", child_1_5),
+                    TestTokens.CloseBracket
+                },
+                ChildContexts = new List<TestContextInstance>()
+                {
+                    child_1_5
+                }
+            };
+
+            var child_1_3 = new TestContextInstance(testContext)
+            {
+                Contents = "[[()]]",
+                Depth = 3,
+                Tokens = new List<TestTokenInstance>()
+                {
+                    TestTokens.OpenBracket,
+                    TestTokens.ChildContext("[()]", child_1_4),
+                    TestTokens.CloseBracket
+                },
+                ChildContexts = new List<TestContextInstance>()
+                {
+                    child_1_4
+                }
+            };
+
+            var child_1_2 = new TestContextInstance(testContext)
+            {
+                Contents = "{[[()]]}",
+                Depth = 2,
+                Tokens = new List<TestTokenInstance>()
+                {
+                    TestTokens.OpenBrace,
+                    TestTokens.ChildContext("[[()]]", child_1_3),
+                    TestTokens.CloseBrace
+                },
+                ChildContexts = new List<TestContextInstance>()
+                {
+                    child_1_3
+                }
+            };
+
+            var child_1_1 = new TestContextInstance(testContext)
+            {
+                Contents = "[{[[()]]}]",
+                Depth = 1,
+                Tokens = new List<TestTokenInstance>()
+                {
+                    TestTokens.OpenBracket,
+                    TestTokens.ChildContext("{[[()]]}", child_1_2),
+                    TestTokens.CloseBracket
+                },
+                ChildContexts = new List<TestContextInstance>()
+                {
+                    child_1_2
+                }
+            };
+
+            var child = new TestContextInstance(testContext)
             {
                 Contents = contentToParse,
                 Depth = 0,
                 Tokens = new List<TestTokenInstance>()
                 {
-                    TestTokens.OpenBracket,
-                    TestTokens.CloseBracket
+                    TestTokens.ChildContext("[{[[()]]}]", child_1_1)
                 },
                 ChildContexts = new List<TestContextInstance>()
                 {
-                    new TestContextInstance(testContext)
-                    {
-                        Contents = "[{[[()]]}]",
-                        Depth = 1,
-                        Tokens = new List<TestTokenInstance>()
-                        {
-                            TestTokens.OpenBracket,
-                            TestTokens.OpenBrace,
-                            TestTokens.CloseBrace,
-                            TestTokens.CloseBracket
-                        },
-                        ChildContexts = new List<TestContextInstance>()
-                        {
-                            new TestContextInstance(testContext)
-                            {
-                                Contents = "{[[()]]}",
-                                Depth = 2,
-                                Tokens = new List<TestTokenInstance>()
-                                {
-                                    TestTokens.OpenBrace,
-                                    TestTokens.OpenBracket,
-                                    TestTokens.CloseBracket,
-                                    TestTokens.CloseBrace                                   
-                                },
-                                ChildContexts = new List<TestContextInstance>()
-                                {
-                                    new TestContextInstance(testContext)
-                                    {
-                                        Contents = "[[()]]",
-                                        Depth = 3,
-                                        Tokens = new List<TestTokenInstance>()
-                                        {
-                                            TestTokens.OpenBracket,
-                                            TestTokens.OpenBracket,
-                                            TestTokens.CloseBracket,
-                                            TestTokens.CloseBracket
-                                        },
-                                        ChildContexts = new List<TestContextInstance>()
-                                        {
-                                            new TestContextInstance(testContext)
-                                            {
-                                                Contents = "[()]",
-                                                Depth = 4,
-                                                Tokens = new List<TestTokenInstance>()
-                                                {
-                                                    TestTokens.OpenBracket,
-                                                    TestTokens.OpenParens,
-                                                    TestTokens.CloseParens,
-                                                    TestTokens.CloseBracket
-                                                },
-                                                ChildContexts= new List<TestContextInstance>()
-                                                {
-                                                    new TestContextInstance(testContext)
-                                                    {
-                                                        Contents = "()",
-                                                        Depth = 5,
-                                                        Tokens = new List<TestTokenInstance>()
-                                                        {
-                                                            TestTokens.OpenParens,
-                                                            TestTokens.CloseParens
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+                    child_1_1
                 }
             };
+
+            TestContextInstance expected = child;
 
             var testArgs = new TestParseArgs<TestContext>()
             {
@@ -330,91 +346,99 @@ namespace BasicTests.Theories
 
             args.Add(YoggTreeTestHelper.ToObjArray(testArgs));
 
+            /****************************************************************************************/
+
             contentToParse = "abcd[cats{are[\tgreat[pets] to] keep}not lonely]efgh";
             testContext = new TestContext();
 
-            expected = new TestContextInstance(testContext)
+            child_1_4 = new TestContextInstance(testContext)
+            {
+                Contents = "[pets]",
+                Depth = 4,
+                Tokens = new List<TestTokenInstance>()
+                {
+                    TestTokens.OpenBracket,
+                    TestTokens.TextContent("pets"),
+                    TestTokens.CloseBracket
+                }
+            };
+
+            child_1_3 = new TestContextInstance(testContext)
+            {
+                Contents = "[\tgreat[pets] to]",
+                Depth = 3,
+                Tokens = new List<TestTokenInstance>()
+                {
+                    TestTokens.OpenBracket,
+                    TestTokens.HorizontalWhitespace("\t"),
+                    TestTokens.TextContent("great"),
+                    TestTokens.ChildContext("[pets]", child_1_4),
+                    TestTokens.HorizontalWhitespace(" "),
+                    TestTokens.TextContent("to"),
+                    TestTokens.CloseBracket
+                },
+                ChildContexts = new List<TestContextInstance>()
+                {
+                    child_1_4
+                }
+            };
+
+            child_1_2 = new TestContextInstance(testContext)
+            {
+                Contents = "{are[\tgreat[pets] to] keep}",
+                Depth = 2,
+                Tokens = new List<TestTokenInstance>()
+                {
+                    TestTokens.OpenBrace,
+                    TestTokens.TextContent("are"),
+                    TestTokens.ChildContext("[\tgreat[pets] to]", child_1_3),
+                    TestTokens.HorizontalWhitespace(" "),
+                    TestTokens.TextContent("keep"),
+                    TestTokens.CloseBrace
+                },
+                ChildContexts = new List<TestContextInstance>()
+                {
+                    child_1_3
+                }
+            };
+
+            child_1_1 = new TestContextInstance(testContext)
+            {
+                Contents = "[cats{are[\tgreat[pets] to] keep}not lonely]",
+                Depth = 1,
+                Tokens = new List<TestTokenInstance>()
+                {
+                    TestTokens.OpenBracket,
+                    TestTokens.TextContent("cats"),
+                    TestTokens.ChildContext("{are[\tgreat[pets] to] keep}", child_1_2),
+                    TestTokens.TextContent("not"),
+                    TestTokens.HorizontalWhitespace(" "),
+                    TestTokens.TextContent("lonely"),
+                    TestTokens.CloseBracket
+                },
+                ChildContexts = new List<TestContextInstance>()
+                {
+                    child_1_2
+                }
+            };
+
+            child = new TestContextInstance(testContext)
             {
                 Contents = contentToParse,
                 Depth = 0,
                 Tokens = new List<TestTokenInstance>()
                 {
                     TestTokens.TextContent("abcd"),
-                    TestTokens.OpenBracket,
-                    TestTokens.CloseBracket,
+                    TestTokens.ChildContext("[cats{are[\tgreat[pets] to] keep}not lonely]", child_1_1),
                     TestTokens.TextContent("efgh")
                 },
                 ChildContexts = new List<TestContextInstance>()
-                {
-                    new TestContextInstance(testContext)
-                    {
-                        Contents = "[cats{are[\tgreat[pets] to] keep}not lonely]",
-                        Depth = 1,
-                        Tokens = new List<TestTokenInstance>()
-                        {
-                            TestTokens.OpenBracket,
-                            TestTokens.TextContent("cats"),
-                            TestTokens.OpenBrace,
-                            TestTokens.CloseBrace,
-                            TestTokens.TextContent("not"),
-                            TestTokens.HorizontalWhitespace(" "),
-                            TestTokens.TextContent("lonely"),
-                            TestTokens.CloseBracket
-                        },
-                        ChildContexts = new List<TestContextInstance>()
-                        {
-                            new TestContextInstance(testContext)
-                            {
-                                Contents = "{are[\tgreat[pets] to] keep}",
-                                Depth = 2,
-                                Tokens = new List<TestTokenInstance>()
-                                {
-                                    TestTokens.OpenBrace,
-                                    TestTokens.TextContent("are"),
-                                    TestTokens.OpenBracket,
-                                    TestTokens.CloseBracket,
-                                    TestTokens.HorizontalWhitespace(" "),
-                                    TestTokens.TextContent("keep"),
-                                    TestTokens.CloseBrace
-                                },
-                                ChildContexts = new List<TestContextInstance>()
-                                {
-                                    new TestContextInstance(testContext)
-                                    {
-                                        Contents = "[\tgreat[pets] to]",
-                                        Depth = 3,
-                                        Tokens = new List<TestTokenInstance>()
-                                        {
-                                            TestTokens.OpenBracket,
-                                            TestTokens.HorizontalWhitespace("\t"),
-                                            TestTokens.TextContent("great"),
-                                            TestTokens.OpenBracket,
-                                            TestTokens.CloseBracket,
-                                            TestTokens.HorizontalWhitespace(" "),
-                                            TestTokens.TextContent("to"),
-                                            TestTokens.CloseBracket
-                                        },
-                                        ChildContexts = new List<TestContextInstance>()
-                                        {
-                                            new TestContextInstance(testContext)
-                                            {
-                                                Contents = "[pets]",
-                                                Depth = 4,
-                                                Tokens = new List<TestTokenInstance>()
-                                                {
-                                                    TestTokens.OpenBracket,
-                                                    TestTokens.TextContent("pets"),
-                                                    TestTokens.CloseBracket
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+                { 
+                    child_1_1
                 }
             };
+
+            expected = child;
 
             testArgs = new TestParseArgs<TestContext>()
             {

--- a/YoggTree/YoggTree/Core/Tokens/BackslashToken.cs
+++ b/YoggTree/YoggTree/Core/Tokens/BackslashToken.cs
@@ -8,9 +8,9 @@ namespace YoggTree.Core.Tokens
     /// <summary>
     /// Token for finding "\" characters.
     /// </summary>
-    public class Backslash : TokenDefinition
+    public class BackslashToken : TokenDefinition
     {
-        public Backslash() 
+        public BackslashToken() 
             : base(TokenRegexStore.Backslash, "\\")
         {
         }

--- a/YoggTree/YoggTree/Core/Tokens/Brackets.cs
+++ b/YoggTree/YoggTree/Core/Tokens/Brackets.cs
@@ -11,7 +11,7 @@ namespace YoggTree.Core.Tokens
     public class OpenBracketToken : TokenDefinition
     {
         public OpenBracketToken()
-            : base(TokenRegexStore.Brace_OpenBracket, "[", TokenTypeFlags.ContextStarter, "Brace_Bracket")
+            : base(TokenRegexStore.Brace_OpenBracket, "[", TokenDefinitionFlags.ContextStarter, "Brace_Bracket")
         {
         }
     }
@@ -22,7 +22,7 @@ namespace YoggTree.Core.Tokens
     public class CloseBracketToken : TokenDefinition
     {
         public CloseBracketToken()
-            : base(TokenRegexStore.Brace_CloseBracket, "]", TokenTypeFlags.ContextEnder, "Brace_Bracket")
+            : base(TokenRegexStore.Brace_CloseBracket, "]", TokenDefinitionFlags.ContextEnder, "Brace_Bracket")
         {
         }
     }

--- a/YoggTree/YoggTree/Core/Tokens/CurlyBraces.cs
+++ b/YoggTree/YoggTree/Core/Tokens/CurlyBraces.cs
@@ -11,7 +11,7 @@ namespace YoggTree.Core.Tokens
     public class OpenCurlyBraceToken : TokenDefinition
     {
         public OpenCurlyBraceToken()
-            : base(TokenRegexStore.Brace_OpenCurly, "{", TokenTypeFlags.ContextStarter, "Brace_Curly")
+            : base(TokenRegexStore.Brace_OpenCurly, "{", TokenDefinitionFlags.ContextStarter, "Brace_Curly")
         {
         }
     }
@@ -22,7 +22,7 @@ namespace YoggTree.Core.Tokens
     public class CloseCurlyBraceToken : TokenDefinition
     {
         public CloseCurlyBraceToken()
-            : base(TokenRegexStore.Brace_CloseCurly, "}", TokenTypeFlags.ContextEnder, "Brace_Curly")
+            : base(TokenRegexStore.Brace_CloseCurly, "}", TokenDefinitionFlags.ContextEnder, "Brace_Curly")
         {
         }
     }

--- a/YoggTree/YoggTree/Core/Tokens/EmptyToken.cs
+++ b/YoggTree/YoggTree/Core/Tokens/EmptyToken.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace YoggTree.Core.Tokens
+{
+    /// <summary>
+    /// Represents a token that is an empty placeholder for a TokenDefinition in certain TokenInstances.
+    /// </summary>
+    public class EmptyToken : TokenDefinition
+    {
+        public EmptyToken()
+            :base(new Regex(""), "<empty>")
+        {
+
+        }
+    }
+}

--- a/YoggTree/YoggTree/Core/Tokens/ForwardslashToken.cs
+++ b/YoggTree/YoggTree/Core/Tokens/ForwardslashToken.cs
@@ -8,9 +8,9 @@ namespace YoggTree.Core.Tokens
     /// <summary>
     /// Token for finding "/" characters.
     /// </summary>
-    public class Forwardslash : TokenDefinition
+    public class ForwardslashToken : TokenDefinition
     {
-        public Forwardslash() 
+        public ForwardslashToken() 
             : base(TokenRegexStore.Forwardslash, "/")
         {
         }

--- a/YoggTree/YoggTree/Core/Tokens/Parenthesis.cs
+++ b/YoggTree/YoggTree/Core/Tokens/Parenthesis.cs
@@ -14,10 +14,10 @@ namespace YoggTree.Core.Tokens
     /// <summary>
     /// Token for finding "(" characters.
     /// </summary>
-    public class Parenthesis_Open : TokenDefinition
+    public class Parenthesis_OpenToken : TokenDefinition
     {
-        public Parenthesis_Open()
-            :base(TokenRegexStore.Parenthesis_Open, "(", TokenTypeFlags.ContextStarter, "Parenthesis")
+        public Parenthesis_OpenToken()
+            :base(TokenRegexStore.Parenthesis_Open, "(", TokenDefinitionFlags.ContextStarter, "Parenthesis")
         {
 
         }
@@ -26,10 +26,10 @@ namespace YoggTree.Core.Tokens
     /// <summary>
     /// Token for finding ")" characters.
     /// </summary>
-    public class Parenthesis_Close : TokenDefinition
+    public class Parenthesis_CloseToken : TokenDefinition
     {
-        public Parenthesis_Close()
-            : base(TokenRegexStore.Parenthesis_Close, ")", TokenTypeFlags.ContextEnder, "Parenthesis")
+        public Parenthesis_CloseToken()
+            : base(TokenRegexStore.Parenthesis_Close, ")", TokenDefinitionFlags.ContextEnder, "Parenthesis")
         {
 
         }

--- a/YoggTree/YoggTree/Core/Tokens/StringDoubleQuoteToken.cs
+++ b/YoggTree/YoggTree/Core/Tokens/StringDoubleQuoteToken.cs
@@ -8,10 +8,10 @@ namespace YoggTree.Core.Tokens
     /// <summary>
     /// Token for finding " characters.
     /// </summary>
-    public class StringDoubleQuote : TokenDefinition
+    public class StringDoubleQuoteToken : TokenDefinition
     {
-        public StringDoubleQuote() 
-            : base(TokenRegexStore.DoubleQuote, "\"", TokenTypeFlags.ContextEnder | TokenTypeFlags.ContextStarter, "StringDoubleQuote") 
+        public StringDoubleQuoteToken() 
+            : base(TokenRegexStore.DoubleQuote, "\"", TokenDefinitionFlags.ContextEnder | TokenDefinitionFlags.ContextStarter, "StringDoubleQuoteToken") 
         { 
         }
     }

--- a/YoggTree/YoggTree/Core/Tokens/StringGraveToken.cs
+++ b/YoggTree/YoggTree/Core/Tokens/StringGraveToken.cs
@@ -8,10 +8,10 @@ namespace YoggTree.Core.Tokens
     /// <summary>
     /// Token for finding "`" characters.
     /// </summary>
-    public class StringGrave : TokenDefinition
+    public class StringGraveToken : TokenDefinition
     {
-        public StringGrave()
-            : base(TokenRegexStore.Grave, "`", TokenTypeFlags.ContextEnder | TokenTypeFlags.ContextStarter, "StringGrave")
+        public StringGraveToken()
+            : base(TokenRegexStore.Grave, "`", TokenDefinitionFlags.ContextEnder | TokenDefinitionFlags.ContextStarter, "StringGraveToken")
         {
         }
     }

--- a/YoggTree/YoggTree/Core/Tokens/StringSingleQuoteToken.cs
+++ b/YoggTree/YoggTree/Core/Tokens/StringSingleQuoteToken.cs
@@ -8,10 +8,10 @@ namespace YoggTree.Core.Tokens
     /// <summary>
     /// Token for finding "'" characters.
     /// </summary>
-    public class StringSingleQuote : TokenDefinition
+    public class StringSingleQuoteToken : TokenDefinition
     {
-        public StringSingleQuote() 
-            : base(TokenRegexStore.SingleQuote, "'", TokenTypeFlags.ContextEnder | TokenTypeFlags.ContextStarter, "StringSingleQuote") 
+        public StringSingleQuoteToken() 
+            : base(TokenRegexStore.SingleQuote, "'", TokenDefinitionFlags.ContextEnder | TokenDefinitionFlags.ContextStarter, "StringSingleQuoteToken") 
         { 
         }
     }

--- a/YoggTree/YoggTree/Core/Tokens/TextContentToken.cs
+++ b/YoggTree/YoggTree/Core/Tokens/TextContentToken.cs
@@ -12,12 +12,12 @@ using System.Threading.Tasks;
 
 namespace YoggTree.Core.Tokens
 {
-    public sealed class TextContent : TokenDefinition
+    /// <summary>
+    /// Placeholder token for spans of text that is between two sequential tokens. WARNING: Never include in the ValidTokens list as this will match the entire string - this is used by the TokenContextInstance to make spans of plain text on the fly.
+    /// </summary>
+    public sealed class TextContentToken : TokenDefinition
     {
-        /// <summary>
-        /// Placeholder token for spans of text that is between two sequential tokens. WARNING: Never include in the ValidTokens list as this will match the entire string - this is used by the TokenContextInstance to make spans of plain text on the fly.
-        /// </summary>
-        public TextContent()
+        public TextContentToken()
             : base(new Regex(".+"), "<text content>")
         {
 

--- a/YoggTree/YoggTree/Core/Tokens/WhitespaceHorizontalToken.cs
+++ b/YoggTree/YoggTree/Core/Tokens/WhitespaceHorizontalToken.cs
@@ -8,9 +8,9 @@ namespace YoggTree.Core.Tokens
     /// <summary>
     /// Token for finding all "horizontal" (non-line breaking) whitespace characters that are not separated by a non-whitespace character.
     /// </summary>
-    public class WhitespaceHorizontal : TokenDefinition
+    public class WhitespaceHorizontalToken : TokenDefinition
     {
-        public WhitespaceHorizontal() 
+        public WhitespaceHorizontalToken() 
             : base(TokenRegexStore.Whitespace_Horizontal, "<horizontal whitespace>", 100)
         {
         }

--- a/YoggTree/YoggTree/Core/Tokens/WhitespaceVerticalToken.cs
+++ b/YoggTree/YoggTree/Core/Tokens/WhitespaceVerticalToken.cs
@@ -8,9 +8,9 @@ namespace YoggTree.Core.Tokens
     /// <summary>
     /// Token for finding all "vertical" (line breaking) whitespace characters that are not separated by a non-line breaking whitespace character.
     /// </summary>
-    public class WhitespaceVertical : TokenDefinition
+    public class WhitespaceVerticalToken : TokenDefinition
     {
-        public WhitespaceVertical() 
+        public WhitespaceVerticalToken() 
             : base(TokenRegexStore.Whitespace_Vertical, "<vertical whitespace>", 100)
         {
         }

--- a/YoggTree/YoggTree/Enums.cs
+++ b/YoggTree/YoggTree/Enums.cs
@@ -8,12 +8,12 @@ namespace YoggTree
     /// <summary>
     /// Bit flags for indicating special behavior for TokenDefinitions.
     /// </summary>
-    public enum TokenTypeFlags
+    public enum TokenDefinitionFlags
     {
         /// <summary>
-        /// None. Default.
+        /// None. None.
         /// </summary>
-        Default = 0,
+        None = 0,
         /// <summary>
         /// Token marks the start of a new child TokenContextInstance.
         /// </summary>
@@ -22,5 +22,18 @@ namespace YoggTree
         /// Token marks the end of a TokenContextInstance.
         /// </summary>
         ContextEnder = 2
+    }
+
+    public enum TokenInstanceType
+    {
+        None = 0,
+        RegexResult = 1,
+        TextPlaceholder = 2,
+        ContextPlaceholder = 3
+    }
+
+    public enum ContextDefinitionFlags
+    {
+        None = 0
     }
 }

--- a/YoggTree/YoggTree/StandardTokens.cs
+++ b/YoggTree/YoggTree/StandardTokens.cs
@@ -21,25 +21,27 @@ namespace YoggTree
 
         public readonly static CloseCurlyBraceToken CloseCurlyBrace = new CloseCurlyBraceToken();
 
-        public readonly static StringDoubleQuote DoubleQuote = new StringDoubleQuote();
+        public readonly static StringDoubleQuoteToken DoubleQuote = new StringDoubleQuoteToken();
 
-        public readonly static StringSingleQuote SingleQuote = new StringSingleQuote();
+        public readonly static StringSingleQuoteToken SingleQuote = new StringSingleQuoteToken();
 
-        public readonly static StringGrave Grave = new StringGrave();
+        public readonly static StringGraveToken Grave = new StringGraveToken();
 
-        public readonly static WhitespaceHorizontal WhitespaceHorizontal = new WhitespaceHorizontal();
+        public readonly static WhitespaceHorizontalToken WhitespaceHorizontal = new WhitespaceHorizontalToken();
 
-        public readonly static WhitespaceVertical WhitespaceVertical = new WhitespaceVertical();
+        public readonly static WhitespaceVerticalToken WhitespaceVertical = new WhitespaceVerticalToken();
 
-        public readonly static Backslash Backslash = new Backslash();
+        public readonly static BackslashToken Backslash = new BackslashToken();
 
-        public readonly static Forwardslash Forwardslash = new Forwardslash();
+        public readonly static ForwardslashToken Forwardslash = new ForwardslashToken();
 
-        public readonly static Parenthesis_Open OpenParenthesis = new Parenthesis_Open();
+        public readonly static Parenthesis_OpenToken OpenParenthesis = new Parenthesis_OpenToken();
 
-        public readonly static Parenthesis_Close CloseParenthsis= new Parenthesis_Close();
+        public readonly static Parenthesis_CloseToken CloseParenthsis = new Parenthesis_CloseToken();
 
-        public readonly static TextContent TextContent = new TextContent();
+        public readonly static TextContentToken TextContent = new TextContentToken();
+
+        public readonly static EmptyToken Empty = new EmptyToken();
 
         /// <summary>
         /// Gets the horizontal and vertical whitespace tokens.
@@ -107,6 +109,10 @@ namespace YoggTree
             };
         }
 
+        /// <summary>
+        /// Gets the "(" and ")" characters.
+        /// </summary>
+        /// <returns></returns>
         public static List<TokenDefinition> GetParenthesisTokens()
         {
             return new List<TokenDefinition>()

--- a/YoggTree/YoggTree/TokenDefinition.cs
+++ b/YoggTree/YoggTree/TokenDefinition.cs
@@ -16,7 +16,7 @@ namespace YoggTree
 
         protected readonly string _name = null;
         protected readonly Regex _token = null;
-        protected readonly TokenTypeFlags _flags = TokenTypeFlags.Default;
+        protected readonly TokenDefinitionFlags _flags = TokenDefinitionFlags.None;
         protected readonly string _contextKey = null;
         protected readonly int _spoolSize = 25;
 
@@ -45,9 +45,9 @@ namespace YoggTree
         }
 
         /// <summary>
-        /// Flags indicating special behavior to be taken when the default implementations of TokenInstances and TokenContextInstances is used.
+        /// Flags indicating special behavior to be taken when this token is encountered.
         /// </summary>
-        public TokenTypeFlags Flags
+        public TokenDefinitionFlags Flags
         {
             get
             {
@@ -113,11 +113,11 @@ namespace YoggTree
         /// <param name="name">The human readable name of the token.</param>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentException"></exception>
-        public TokenDefinition(Regex token, string name, TokenTypeFlags flags, string contextKey = null, int? spoolSize = null)
+        public TokenDefinition(Regex token, string name, TokenDefinitionFlags flags, string contextKey = null, int? spoolSize = null)
         {
             if (token == null) throw new ArgumentNullException(nameof(token));
             if (string.IsNullOrWhiteSpace(name) == true) throw new ArgumentException(nameof(name));
-            if (flags.HasFlag(TokenTypeFlags.ContextStarter) || flags.HasFlag(TokenTypeFlags.ContextEnder))
+            if (flags.HasFlag(TokenDefinitionFlags.ContextStarter) || flags.HasFlag(TokenDefinitionFlags.ContextEnder))
             {
                 if (string.IsNullOrEmpty(contextKey) == true) throw new ArgumentException("When using ContextStarter or ContextEnder flags, the contextKey must be a non-empty string.");
                 _contextKey = contextKey;

--- a/YoggTree/YoggTree/TokenInstance.cs
+++ b/YoggTree/YoggTree/TokenInstance.cs
@@ -1,4 +1,5 @@
-﻿using System.Xml.Linq;
+﻿using System.Runtime.CompilerServices;
+using System.Xml.Linq;
 /**Copyright (c) 2023 Richard H Stannard
 
 This source code is licensed under the MIT license found in the
@@ -9,7 +10,7 @@ namespace YoggTree
     /// <summary>
     /// Represents an instance of a TokenDefinition that was found in a TokenContextInstance's Content.
     /// </summary>
-    public sealed record TokenInstance
+    public record TokenInstance
     {
         /// <summary>
         /// The definition of the rules for the token.
@@ -37,9 +38,9 @@ namespace YoggTree
         public int EndIndex { get; internal init; } = -1;
 
         /// <summary>
-        /// If this token successfully started a new context as it was being processed, this was the context that was started and can be drilled into recursively. 
+        /// The type of instance this token represents.
         /// </summary>
-        public TokenContextInstance StartedContextInstance { get; internal init; } = null;
+        public TokenInstanceType TokenInstanceType { get; } = TokenInstanceType.None;
 
         /// <summary>
         /// Internal constructor used to make a new TokenInstance.
@@ -51,7 +52,7 @@ namespace YoggTree
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         /// <exception cref="ArgumentException"></exception>
-        internal TokenInstance(TokenDefinition tokenDefinition, TokenContextInstance context, int tokenStartIndex, ReadOnlyMemory<char> value)
+        internal TokenInstance(TokenDefinition tokenDefinition, TokenContextInstance context, int tokenStartIndex, ReadOnlyMemory<char> value, TokenInstanceType instanceType)
         {
             if (tokenDefinition == null) throw new ArgumentNullException("token");
             if (context == null) throw new ArgumentNullException("targetContext");
@@ -63,6 +64,56 @@ namespace YoggTree
             StartIndex = tokenStartIndex;
             Contents = value;
             EndIndex = StartIndex + value.Length;
+            TokenInstanceType = instanceType;
+        }        
+
+        public override string ToString()
+        {
+            return $"{TokenDefinition.GetType().Name} @:{StartIndex}=\"{Contents}\"";
+        }
+    }
+
+    /// <summary>
+    /// Represents an instance of a token that wraps a child TokenContextInstance.
+    /// </summary>
+    public record ChildContextTokenInstance : TokenInstance
+    {
+        public TokenContextInstance ChildContext { get; internal init; } = null;
+
+        internal ChildContextTokenInstance(TokenContextInstance context, int tokenStartIndex, ReadOnlyMemory<char> value, TokenContextInstance childContext)
+            : base(StandardTokens.Empty, context, tokenStartIndex, value, TokenInstanceType.ContextPlaceholder)
+        {
+            ChildContext = childContext;
+        }
+    }
+
+    /// <summary>
+    /// Represents an instance of a token that is a run of text between other tokens.
+    /// </summary>
+    public record TextPlacehodlerTokenInstance : TokenInstance
+    { 
+        internal TextPlacehodlerTokenInstance(TokenContextInstance context, int tokenStartIndex, ReadOnlyMemory<char> value)
+            :base (StandardTokens.TextContent, context, tokenStartIndex, value, TokenInstanceType.TextPlaceholder)
+        {
+
+        }
+    }
+
+    public static class TokenInstanceExtensions
+    {
+        /// <summary>
+        /// If the TokenInstance is a ChildContextTokenInstance, this will return the TokenContextInstance being wrapped.
+        /// </summary>
+        /// <param name="instance"></param>
+        /// <returns></returns>
+        public static TokenContextInstance GetChildContext(this TokenInstance instance)
+        {
+            return (instance as ChildContextTokenInstance)?.ChildContext;
+        }
+
+        public static string GetText(this TokenInstance instance)
+        {
+            return (instance == null) ? null : instance.Contents.ToString();
         }
 
         /// <summary>
@@ -70,12 +121,12 @@ namespace YoggTree
         /// </summary>
         /// <param name="targetContext"></param>
         /// <returns></returns>
-        public TokenInstance GetContextualInstance(TokenContextInstance targetContext)
+        public static TokenInstance GetContextualInstance(this TokenInstance instance, TokenContextInstance targetContext)
         {
-            int contextualStartIndex = GetContextualStartIndex(targetContext);
-            int delta = contextualStartIndex - StartIndex;
+            int contextualStartIndex = instance.GetContextualStartIndex(targetContext);
+            int delta = contextualStartIndex - instance.StartIndex;
 
-            return this with { Context = targetContext, EndIndex = EndIndex + delta, StartIndex = StartIndex + delta };
+            return instance with { Context = targetContext, EndIndex = instance.EndIndex + delta, StartIndex = instance.StartIndex + delta };
         }
 
         /// <summary>
@@ -83,10 +134,10 @@ namespace YoggTree
         /// </summary>
         /// <returns></returns>
         /// <exception cref="Exception"></exception>
-        public TokenInstance GetAbsoluteInstance()
+        public static TokenInstance GetAbsoluteInstance(this TokenInstance instance)
         {
-            if (Context?.ParseSession == null) throw new Exception("Token does not belong to a parse session, cannot get absolute instance.");
-            return GetContextualInstance(Context?.ParseSession?.RootContext);
+            if (instance?.Context?.ParseSession == null) throw new Exception("Token does not belong to a parse session, cannot get absolute instance.");
+            return instance.GetContextualInstance(instance?.Context?.ParseSession?.RootContext);
         }
 
         /// <summary>
@@ -96,14 +147,14 @@ namespace YoggTree
         /// <returns></returns>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="Exception"></exception>
-        private int GetContextualStartIndex(TokenContextInstance targetContext)
+        private static int GetContextualStartIndex(this TokenInstance instance, TokenContextInstance targetContext)
         {
             if (targetContext == null) throw new ArgumentNullException(nameof(targetContext));
-            if (StartIndex < 0) throw new Exception("StartIndex must be a positive number.");
+            if (instance.StartIndex < 0) throw new Exception("StartIndex must be a positive number.");
 
             bool parentFound = false;
 
-            TokenContextInstance parent = Context.Parent;
+            TokenContextInstance parent = instance.Context.Parent;
 
             while (parent != null)
             {
@@ -118,12 +169,7 @@ namespace YoggTree
 
             if (parentFound != true) throw new Exception("TokenInstance is not contained by the target targetContext.");
 
-            return StartIndex + parent.AbsoluteOffset;
-        }
-
-        public override string ToString()
-        {
-            return $"{TokenDefinition.GetType().Name} @:{StartIndex}=\"{Contents}\"";
+            return instance.StartIndex + parent.AbsoluteOffset;
         }
     }
 }


### PR DESCRIPTION
Renamed all standard tokens to end in "Token", fleshed out the idea of context and text placeholder tokens. Got all tests rewritten and passing.