### PR TITLE
Fixed bugs in token parsing and ensured the results of GetNextToken() and GetPreviousToken() are consistent with their context's Tokens list.

### DIFF
--- a/YoggTree/Tests/BasicTests/Common/YoggTreeTestHelper.cs
+++ b/YoggTree/Tests/BasicTests/Common/YoggTreeTestHelper.cs
@@ -8,6 +8,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Transactions;
+using YoggTree.Core.Tokens;
 
 namespace YoggTreeTest.Common
 {
@@ -45,6 +47,96 @@ namespace YoggTreeTest.Common
             }
 
             return true;
+        }
+
+        public static bool ValidateSeekResults<T>(TestParseArgs<T> parseArgs) where T : TokenContextDefinition, new()
+        {
+            var parser = new TokenParser();
+            var result = parser.Parse(new T(), parseArgs.ContentToParse);
+
+            WalkTokens(result);
+
+            return true;
+        }
+
+        private static void WalkTokens(TokenContextInstance contextInstance)
+        {
+            if (contextInstance.Parent != null)
+            {
+                if (contextInstance.Tokens.Count == 0)
+                {
+                    if (contextInstance.StartToken.GetNextToken() != contextInstance.EndToken)
+                    {
+                        throw new Exception($"Token mismatch: StartToken's nect token for empty context {contextInstance} did not match EndToken. Expected: {contextInstance.EndToken} Actual: {contextInstance.StartToken.GetNextToken()}");
+                    }
+
+                    if (contextInstance.EndToken.GetPreviousToken() != contextInstance.StartToken)
+                    {
+                        throw new Exception($"Token mismatch: EndToken's previous token for empty context {contextInstance} did not match StartToken. Expected: {contextInstance.StartToken} Actual: {contextInstance.EndToken.GetPreviousToken()}");
+                    }
+                }
+                if (contextInstance.Tokens.Count > 0 && contextInstance.Parent != null) //this check doesn't apply to the root context
+                {
+                    if (contextInstance.Tokens[0] != contextInstance.StartToken)
+                    {
+                        throw new Exception($"Token mismatch: StartToken for context {contextInstance} did not match at index 0. Expected: {contextInstance.StartToken} Actual: {contextInstance.Tokens[0]}");
+                    }
+                    else if (contextInstance.Tokens[contextInstance.Tokens.Count - 1] != contextInstance.EndToken)
+                    {
+                        throw new Exception($"Token mismatch: EndToken for context {contextInstance} did not match at index {contextInstance.Tokens.Count - 1}. Expected: {contextInstance.EndToken} Actual: {contextInstance.Tokens[contextInstance.Tokens.Count - 1]}");
+                    }
+                }
+            }
+
+            for (int x = 0; x < contextInstance.Tokens.Count; x++)
+            {
+                var curToken = contextInstance.Tokens[x];
+
+                if (x == 0) //first token of new context
+                {
+                    if (contextInstance.Parent == null)
+                    {
+                        if (curToken.GetPreviousToken() != null) throw new Exception("Starting token in root context had a previous token.");
+                    }
+                    else
+                    {
+                        
+                        int index = -1;
+                        var placeholder = contextInstance.Parent.Tokens.FirstOrDefault(token => { index++; return token.GetChildContext() == contextInstance; });
+                        if (placeholder == null) throw new Exception($"Context placeholder {placeholder} not found in parent context {contextInstance.Parent}");
+
+                        if (index == 0 && contextInstance.Parent.Depth == 0)
+                        {
+                            if (placeholder.GetPreviousToken() != null) throw new Exception("Starting token in first child context had a previous token.");
+                        }
+                        else
+                        {
+                            if (placeholder.GetChildContext().StartToken != curToken) throw new Exception($"Token mismatch: Starting token for context {contextInstance} did not match placeholder's preceding token at index {x}. Expected: {contextInstance.StartToken} Actual: {placeholder.GetPreviousToken()}");
+                        }
+                    }
+                }
+                else if (x < contextInstance.Tokens.Count - 1) //token in middle of context
+                {
+                    if (curToken.GetPreviousToken() != contextInstance.Tokens[x -1]) throw new Exception($"Token mismatch: Token for context {contextInstance} did not match the context's preceding token at index {x - 1}. Expected: {contextInstance.Tokens[x - 1]} Actual: {curToken.GetPreviousToken()}");
+                    if (curToken.GetNextToken() != contextInstance.Tokens[x + 1]) throw new Exception($"Token mismatch: Token for context {contextInstance} did not match the context's preceding token at index {x + 1}. Expected: {contextInstance.Tokens[x + 1]} Actual: {curToken.GetNextToken()}");
+                }
+                else
+                {
+                    if (contextInstance.Parent == null)
+                    {
+                        if (curToken.GetNextToken() != null) throw new Exception("Ending token in root context had a following token.");
+                    }
+                    else
+                    {
+                        if (curToken != contextInstance.EndToken) throw new Exception($"Token mismatch: Token for context {contextInstance} did not match the context's EndToken. Expected: {contextInstance.EndToken} Actual: {curToken}");
+                    }
+                }
+
+                if (curToken.TokenInstanceType == TokenInstanceType.ContextPlaceholder)
+                {
+                    WalkTokens(curToken.GetChildContext());
+                }
+            }
         }
 
         public static object[] ToObjArray(params object[] args)

--- a/YoggTree/Tests/BasicTests/Specs/Spec_Basic_Parse.cs
+++ b/YoggTree/Tests/BasicTests/Specs/Spec_Basic_Parse.cs
@@ -49,5 +49,23 @@ namespace YoggTreeTest.Specs
 
             YoggTreeTestHelper.CompareParseResults(testParseArgs);
         }
+
+        [Theory(DisplayName = "Token list matching tests.")]
+        [ClassData(typeof(Theory_Basic_Parse<TestContext>))]
+        public void MatchTokenList<T>(TestParseArgs<T> testParseArgs) where T : TokenContextDefinition, new()
+        {
+            _output.WriteLine($"Testing: {testParseArgs.TestName}");
+
+            YoggTreeTestHelper.ValidateSeekResults(testParseArgs);
+        }
+
+        [Theory(DisplayName = "Token list matching lazy seeking behavior tests.")]
+        [ClassData(typeof(Theory_Basic_Parse<SeekAheadContext>))]
+        public void MatchLazyTokenList<T>(TestParseArgs<T> testParseArgs) where T : TokenContextDefinition, new()
+        {
+            _output.WriteLine($"Testing: {testParseArgs.TestName}");
+
+            YoggTreeTestHelper.ValidateSeekResults(testParseArgs);
+        }
     }
 }

--- a/YoggTree/YoggTree/Core/Exceptions/TokenSyntaxErrorExecption.cs
+++ b/YoggTree/YoggTree/Core/Exceptions/TokenSyntaxErrorExecption.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace YoggTree.Core.Exceptions
+{
+    /// <summary>
+    /// Exception thrown when a token identifies that is has come before or after a token that is determined to be invalid.
+    /// </summary>
+    public class TokenSyntaxErrorExecption : Exception
+    {
+        public int ContentLineNumber { get; } = -1;
+
+        public int ContentColumnNumber { get; } = -1;
+
+        public TokenSyntaxErrorExecption(string message, int contentLineNumber, int contentColumnNumber)
+            : base(message)
+        {
+            ContentLineNumber = contentLineNumber;
+            ContentColumnNumber = contentColumnNumber;
+        }
+    }
+}

--- a/YoggTree/YoggTree/TokenDefinition.cs
+++ b/YoggTree/YoggTree/TokenDefinition.cs
@@ -157,7 +157,7 @@ namespace YoggTree
         /// </summary>
         /// <param name="instance">The current token instance.</param>
         /// <returns></returns>
-        public bool IsValidInstance(TokenInstance instance)
+        public virtual bool IsValidInstance(TokenInstance instance)
         {
             return true;
         }

--- a/YoggTree/YoggTree/TokenInstance.cs
+++ b/YoggTree/YoggTree/TokenInstance.cs
@@ -1,8 +1,11 @@
-﻿/**Copyright (c) 2023 Richard H Stannard
+﻿
+
+using System.Data.Common;
+using YoggTree.Core.Tokens;
+/**Copyright (c) 2023 Richard H Stannard
 
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.*/
-
 namespace YoggTree
 {
     /// <summary>
@@ -210,6 +213,8 @@ namespace YoggTree
             if (instance == null) return -1;
             if (instance.StartIndex < 0) throw new Exception("StartIndex must be a positive number.");
 
+            return instance.StartIndex + (instance.Context.AbsoluteOffset - targetContext.AbsoluteOffset);
+
             TokenContextInstance currentContext = instance.Context;
             if (currentContext.Depth == targetContext.Depth)
             {
@@ -230,6 +235,39 @@ namespace YoggTree
 
             int delta = currentContext.AbsoluteOffset- targetContext.AbsoluteOffset;
             return instance.StartIndex + delta;
+        }
+
+        /// <summary>
+        /// Gets the line number and column number of the start of the token relative to the entire string being parsed.
+        /// </summary>
+        /// <param name="instance"></param>
+        /// <returns></returns>
+        public static (int LineNumber, int ColumnNumber) GetLineAndColumn(this TokenInstance instance)
+        {
+            if (instance == null) return (-1, -1);
+            
+            int column = -1;
+            int line = 0;
+
+            foreach (var result in TokenRegexStore.Whitespace_Vertical.EnumerateMatches(instance.Context.ParseSession.Contents.Span))
+            {
+                if (result.Index < instance.StartIndex)
+                {
+                    line++;
+                }
+                else
+                {
+                    column = instance.StartIndex - (result.Index + result.Length);
+                    break;
+                }
+            }
+            
+            if (line == 0)
+            {
+                column = instance.StartIndex;
+            }
+
+            return (line, column);
         }
     }
 }


### PR DESCRIPTION
Tweaked token parsing logic to fix small inconsistency bugs and added unit tests for catching consistency bugs between the results of iterating through a context's token list and the results of calling GetNextToken() and GetPreviousToken() after the the parse operation is complete.