### PR TITLE
Added concept of "Unbounded" contexts that do not have end tokens.

### DIFF
--- a/YoggTree/YoggTree/Core/Exceptions/UnexpectedEndOfContentException.cs
+++ b/YoggTree/YoggTree/Core/Exceptions/UnexpectedEndOfContentException.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace YoggTree.Core.Exceptions
+{
+    /// <summary>
+    /// Exception that is thrown when the end of content is reached outside of a context which does not have the Unbounded flag set and is not the root context.
+    /// </summary>
+    public class UnexpectedEndOfContentException : Exception
+    {
+        public UnexpectedEndOfContentException(string message) 
+            : base(message)
+        {
+        }
+    }
+}

--- a/YoggTree/YoggTree/Enums.cs
+++ b/YoggTree/YoggTree/Enums.cs
@@ -61,6 +61,10 @@ namespace YoggTree
         /// <summary>
         /// Default. Not set.
         /// </summary>
-        None = 0
+        None = 0,
+        /// <summary>
+        /// Context does not have an end token and can go to the end of the RootContext's Content.
+        /// </summary>
+        Unbounded = 1,
     }
 }

--- a/YoggTree/YoggTree/TokenContextDefinition.cs
+++ b/YoggTree/YoggTree/TokenContextDefinition.cs
@@ -52,7 +52,7 @@ namespace YoggTree
         /// Creates a new ContextDefinition that is blank once initialized.
         /// </summary>
         /// <param name="name">A name to give the context.</param>
-        /// <param name="flags">Flags to indicate special behavior for this context. Not yet implemented.</param>
+        /// <param name="flags">Flags to indicate special behavior for this context.</param>
         /// <exception cref="ArgumentException"></exception>
         public TokenContextDefinition(string name, ContextDefinitionFlags flags)
         {
@@ -88,7 +88,7 @@ namespace YoggTree
         /// </summary>
         /// <param name="name">A name to give the context.</param>
         /// <param name="validTokens">A set of TokenDefinitions to look for in this context.</param>
-        /// <param name="flags">Flags to indicate special behavior for this context. Not yet implemented.</param>
+        /// <param name="flags">Flags to indicate special behavior for this context.</param>
         /// <exception cref="ArgumentException"></exception>
         public TokenContextDefinition(string name, ContextDefinitionFlags flags, IEnumerable<TokenDefinition> validTokens)
         {

--- a/YoggTree/YoggTree/TokenContextInstance.cs
+++ b/YoggTree/YoggTree/TokenContextInstance.cs
@@ -231,7 +231,7 @@ namespace YoggTree
                     }
                 }
 
-                //check to see if the token defintion allows this token to be valid in its current context, fail if it is not
+                //check to see if the token definition allows this token to be valid in its current context, fail if it is not
                 if (nextToken.TokenDefinition.IsValidInstance(nextToken) == false)
                 {
                     var lineAndCol = nextToken.GetLineAndColumn();
@@ -302,6 +302,12 @@ namespace YoggTree
                 if (previousToken != null) previousToken.NextToken = nextToken;
 
                 previousToken = nextToken;
+            }
+
+            if (EndToken == null)
+            {
+                if (ContextDefinition.Flags.HasFlag(ContextDefinitionFlags.Unbounded) || Parent == null) return;
+                throw new UnexpectedEndOfContentException($"Context {this} had no end token and was not flagged as Unbounded or was not the root of the ParseSession.");
             }
         }
 


### PR DESCRIPTION
Any context that does not have an Unbounded flag set that is not the root context will now throw an exception when it hits the end of the raw content without finding a closing EndToken.