### PR TITLE
Fixed bugs related to the new seeking behavior.

### DIFF
--- a/YoggTree/Tests/BasicTests/Common/TestContext.cs
+++ b/YoggTree/Tests/BasicTests/Common/TestContext.cs
@@ -17,6 +17,17 @@ namespace YoggTreeTest.Common
         public TestContext()
             : base("TestContext")
         {
+            AddTokens();
+        }
+
+        protected TestContext(string name) 
+            : base(name)
+        {
+            AddTokens();
+        }
+
+        private void AddTokens()
+        {
             AddTokens(new List<Type>()
             {
                 typeof(OpenBracketToken),
@@ -44,26 +55,11 @@ namespace YoggTreeTest.Common
         }
     }
 
-    public class SeekAheadContext : TokenContextDefinition
+    public class SeekAheadContext : TestContext
     {
         public SeekAheadContext()
             :base("SeekAhead")
         {
-            AddTokens(new List<Type>()
-            {
-                typeof(OpenBracketToken),
-                typeof(CloseBracketToken),
-                typeof(OpenCurlyBraceToken),
-                typeof(CloseCurlyBraceToken),
-                typeof(StringDoubleQuoteToken),
-                typeof(StringGraveToken),
-                typeof(WhitespaceHorizontalToken),
-                typeof(WhitespaceVerticalToken),
-                typeof(BackslashToken),
-                typeof(ForwardslashToken),
-                typeof(CloseParenthesisToken),
-                typeof(OpenParenthesisToken)
-            });
         }
 
         public override bool StartsNewContext(TokenInstance tokenInstance)
@@ -76,6 +72,19 @@ namespace YoggTreeTest.Common
             }
 
             return base.StartsNewContext(tokenInstance);
+        }
+    }
+
+    public class SparseContext<TChildContext> : TokenContextDefinition where TChildContext : TokenContextDefinition, new()
+    {
+        public SparseContext()
+            : base("SparseContext")
+        {
+            AddTokens(new List<Type>()
+            {
+                typeof(SparseOpenBracketToken<TChildContext>),
+                typeof(SparseCloseBracketToken),
+            });
         }
     }
 }

--- a/YoggTree/Tests/BasicTests/Common/TestTokens.cs
+++ b/YoggTree/Tests/BasicTests/Common/TestTokens.cs
@@ -26,6 +26,8 @@ namespace YoggTreeTest.Common
 
         public static TestTokenInstance CloseParens = new TestTokenInstance(new CloseParenthesisToken()) { Contents = ")" };
 
+        public static TestTokenInstance SparseCloseBracketToken = new TestTokenInstance(new SparseCloseBracketToken(), "]", TokenInstanceType.RegexResult);
+
         public static TestTokenInstance HorizontalWhitespace(string whitespace)
         {
             return new TestTokenInstance(new WhitespaceHorizontalToken(), whitespace, TokenInstanceType.RegexResult);
@@ -47,6 +49,41 @@ namespace YoggTreeTest.Common
             {
                 TestContextInstance = childContext
             };
+        }
+
+        public static TestTokenInstance SparseOpenBracket<TChildContext>() where TChildContext : TokenContextDefinition, new()
+        {
+            return new TestTokenInstance(new SparseOpenBracketToken<TChildContext>(), "[", TokenInstanceType.RegexResult);
+        }
+    }
+
+    public class SparseOpenBracketToken<TChildContext> : TokenDefinition where TChildContext : TokenContextDefinition, new()
+    {
+        public SparseOpenBracketToken()
+            : base(new System.Text.RegularExpressions.Regex("\\["), "[", TokenDefinitionFlags.ContextStarter, "SparseBracket")
+        {
+
+        }
+
+        public override TokenContextDefinition GetNewContextDefinition(TokenInstance start)
+        {
+            var child = new TChildContext();
+
+            child.RemoveToken<OpenBracketToken>();
+            child.RemoveToken<CloseBracketToken>();
+            child.AddToken<SparseOpenBracketToken<TChildContext>>();
+            child.AddToken<SparseCloseBracketToken>();
+
+            return child;
+        }
+    }
+
+    public class SparseCloseBracketToken : TokenDefinition
+    {
+        public SparseCloseBracketToken()
+            : base(new System.Text.RegularExpressions.Regex("\\]"), "]", TokenDefinitionFlags.ContextEnder, "SparseBracket")
+        {
+
         }
     }
 }

--- a/YoggTree/Tests/BasicTests/Specs/Spec_Basic_Parse.cs
+++ b/YoggTree/Tests/BasicTests/Specs/Spec_Basic_Parse.cs
@@ -41,15 +41,6 @@ namespace YoggTreeTest.Specs
             YoggTreeTestHelper.CompareSeekResults(testParseArgs);
         }
 
-        [Theory(DisplayName = "Token lazy seeking tests.")]
-        [ClassData(typeof(Theory_Basic_Parse<SeekAheadContext>))]
-        public void TestLazySeeking<T>(TestParseArgs<T> testParseArgs) where T : TokenContextDefinition, new()
-        {
-            _output.WriteLine($"Testing: {testParseArgs.TestName}");
-
-            YoggTreeTestHelper.CompareParseResults(testParseArgs);
-        }
-
         [Theory(DisplayName = "Token list matching tests.")]
         [ClassData(typeof(Theory_Basic_Parse<TestContext>))]
         public void MatchTokenList<T>(TestParseArgs<T> testParseArgs) where T : TokenContextDefinition, new()
@@ -57,6 +48,15 @@ namespace YoggTreeTest.Specs
             _output.WriteLine($"Testing: {testParseArgs.TestName}");
 
             YoggTreeTestHelper.ValidateSeekResults(testParseArgs);
+        }
+
+        [Theory(DisplayName = "Token lazy seeking tests.")]
+        [ClassData(typeof(Theory_Basic_Parse<SeekAheadContext>))]
+        public void TestLazySeeking<T>(TestParseArgs<T> testParseArgs) where T : TokenContextDefinition, new()
+        {
+            _output.WriteLine($"Testing: {testParseArgs.TestName}");
+
+            YoggTreeTestHelper.CompareParseResults(testParseArgs);
         }
 
         [Theory(DisplayName = "Token list matching lazy seeking behavior tests.")]
@@ -67,5 +67,15 @@ namespace YoggTreeTest.Specs
 
             YoggTreeTestHelper.ValidateSeekResults(testParseArgs);
         }
+
+        [Theory(DisplayName = "Lazy token seek tests.")]
+        [ClassData(typeof(Theory_Basic_Parse<SeekAheadContext>))]
+        public void LazyTokenSeekTests<T>(TestParseArgs<T> testParseArgs) where T : TokenContextDefinition, new()
+        {
+            _output.WriteLine($"Testing: {testParseArgs.TestName}");
+
+            YoggTreeTestHelper.CompareSeekResults(testParseArgs);
+        }
+
     }
 }

--- a/YoggTree/Tests/BasicTests/Specs/Spec_Sparse_Parse.cs
+++ b/YoggTree/Tests/BasicTests/Specs/Spec_Sparse_Parse.cs
@@ -1,0 +1,31 @@
+﻿using BasicTests.Theories;
+using Microsoft.VisualStudio.TestPlatform.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using YoggTreeTest.Theories;
+
+namespace YoggTreeTest.Specs
+{
+    public class Spec_Sparse_Parse
+    {
+        protected ITestOutputHelper _output = null;
+
+        public Spec_Sparse_Parse(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Theory(DisplayName = "Basic parse tests.")]
+        [ClassData(typeof(Theory_Sparse_Parse<SparseContext<TestContext>, TestContext>))]
+        public void ParseDefaultTests<T>(TestParseArgs<T> testParseArgs) where T : TokenContextDefinition, new()
+        {
+            _output.WriteLine($"Testing: {testParseArgs.TestName}");
+
+            YoggTreeTestHelper.CompareParseResults(testParseArgs);
+        }
+    }
+}

--- a/YoggTree/Tests/BasicTests/Theories/Theory_Sparse_Parse.cs
+++ b/YoggTree/Tests/BasicTests/Theories/Theory_Sparse_Parse.cs
@@ -1,0 +1,295 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace YoggTreeTest.Theories
+{
+    internal class Theory_Sparse_Parse<T, TChild> : IEnumerable<Object[]> where T : SparseContext<TChild>, new() where TChild : TestContext, new()
+    {
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            return GetTestArgs().GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        private static List<object[]> GetTestArgs()
+        {
+            List<object[]> args = new List<object[]>();
+
+            MakeSimpleParseArgs(args);
+            MakeGapArgs(args);
+
+            return args;
+        }
+
+        private static void MakeSimpleParseArgs(List<Object[]> args)
+        {
+            string contentToParse = "";
+            TestContextInstance expected = new TestContextInstance(new T())
+            {
+                Contents = contentToParse,
+                Depth = 0
+            };
+
+            var testArgs = new TestParseArgs<T>()
+            {
+                Expected = expected,
+                ContentToParse = contentToParse,
+                TestName = "Empty String Test"
+            };
+
+            args.Add(YoggTreeTestHelper.ToObjArray(testArgs));
+
+            /************************************************************************************/
+
+            contentToParse = " ";
+
+            expected = new TestContextInstance(new T())
+            {
+                Contents = contentToParse,
+                Depth = 0,
+                Tokens = new List<TestTokenInstance>()
+                {
+                    TestTokens.TextContent(" ")
+                }
+            };
+
+            testArgs = new TestParseArgs<T>()
+            {
+                Expected = expected,
+                ContentToParse = contentToParse,
+                TestName = "Single space."
+            };
+
+            args.Add(YoggTreeTestHelper.ToObjArray(testArgs));
+
+            /************************************************************************************/
+
+            contentToParse = "\tabc";
+
+            expected = new TestContextInstance(new T())
+            {
+                Contents = contentToParse,
+                Depth = 0,
+                Tokens = new List<TestTokenInstance>()
+                {
+                    TestTokens.TextContent("\tabc")
+                }
+            };
+
+            testArgs = new TestParseArgs<T>()
+            {
+                Expected = expected,
+                ContentToParse = contentToParse,
+                TestName = "Random text."
+            };
+
+            args.Add(YoggTreeTestHelper.ToObjArray(testArgs));
+        }
+
+        private static void MakeGapArgs(List<object[]> args)
+        {          
+            string contentToParse = "[]";
+
+            var child1 = new TestContextInstance(new TChild())
+            {
+                Contents = "[]",
+                Depth = 1,
+                Tokens = new List<TestTokenInstance>()
+                {
+                    TestTokens.SparseOpenBracket<TChild>(),
+                    TestTokens.SparseCloseBracketToken
+                }
+            };
+
+            var expected = new TestContextInstance(new T())
+            {
+                Contents = contentToParse,
+                Depth = 0,
+                Tokens = new List<TestTokenInstance>()
+                {
+                    TestTokens.ChildContext("[]", child1)
+                },
+                ChildContexts = new List<TestContextInstance> { child1 }
+            };
+
+            var testArgs = new TestParseArgs<T>()
+            {
+                Expected = expected,
+                ContentToParse = contentToParse,
+                TestName = "Empty brackets."
+            };
+
+            args.Add(YoggTreeTestHelper.ToObjArray(testArgs));
+
+            /************************************************************************************/
+
+            contentToParse = "[ abc 123]";
+
+            child1 = new TestContextInstance(new TChild())
+            {
+                Contents = "[ abc 123]",
+                Depth = 1,
+                Tokens = new List<TestTokenInstance>()
+                {
+                    TestTokens.SparseOpenBracket<TChild>(),
+                    TestTokens.HorizontalWhitespace(" "),
+                    TestTokens.TextContent("abc"),
+                    TestTokens.HorizontalWhitespace(" "),
+                    TestTokens.TextContent("123"),
+                    TestTokens.SparseCloseBracketToken
+                }
+            };
+
+            expected = new TestContextInstance(new T())
+            {
+                Contents = contentToParse,
+                Depth = 0,
+                Tokens = new List<TestTokenInstance>()
+                {
+                    TestTokens.ChildContext("[ abc 123]", child1)
+                },
+                ChildContexts = new List<TestContextInstance> { child1 }
+            };
+
+            testArgs = new TestParseArgs<T>()
+            {
+                Expected = expected,
+                ContentToParse = contentToParse,
+                TestName = "Brackets with noise."
+            };
+
+            args.Add(YoggTreeTestHelper.ToObjArray(testArgs));
+
+            /************************************************************************************/
+
+            contentToParse = "test [ abc 123]";
+
+            child1 = new TestContextInstance(new TChild())
+            {
+                Contents = "[ abc 123]",
+                Depth = 1,
+                Tokens = new List<TestTokenInstance>()
+                {
+                    TestTokens.SparseOpenBracket<TChild>(),
+                    TestTokens.HorizontalWhitespace(" "),
+                    TestTokens.TextContent("abc"),
+                    TestTokens.HorizontalWhitespace(" "),
+                    TestTokens.TextContent("123"),
+                    TestTokens.SparseCloseBracketToken
+                }
+            };
+
+            expected = new TestContextInstance(new T())
+            {
+                Contents = contentToParse,
+                Depth = 0,
+                Tokens = new List<TestTokenInstance>()
+                {
+                    TestTokens.TextContent("test "),
+                    TestTokens.ChildContext("[ abc 123]", child1)
+                },
+                ChildContexts = new List<TestContextInstance> { child1 }
+            };
+
+            testArgs = new TestParseArgs<T>()
+            {
+                Expected = expected,
+                ContentToParse = contentToParse,
+                TestName = "Brackets with noise and leading text."
+            };
+
+            args.Add(YoggTreeTestHelper.ToObjArray(testArgs));
+
+            /************************************************************************************/
+
+            contentToParse = "[ abc 123]test ";
+
+            child1 = new TestContextInstance(new TChild())
+            {
+                Contents = "[ abc 123]",
+                Depth = 1,
+                Tokens = new List<TestTokenInstance>()
+                {
+                    TestTokens.SparseOpenBracket<TChild>(),
+                    TestTokens.HorizontalWhitespace(" "),
+                    TestTokens.TextContent("abc"),
+                    TestTokens.HorizontalWhitespace(" "),
+                    TestTokens.TextContent("123"),
+                    TestTokens.SparseCloseBracketToken
+                }
+            };
+
+            expected = new TestContextInstance(new T())
+            {
+                Contents = contentToParse,
+                Depth = 0,
+                Tokens = new List<TestTokenInstance>()
+                {
+
+                    TestTokens.ChildContext("[ abc 123]", child1),
+                    TestTokens.TextContent("test "),
+                },
+                ChildContexts = new List<TestContextInstance> { child1 }
+            };
+
+            testArgs = new TestParseArgs<T>()
+            {
+                Expected = expected,
+                ContentToParse = contentToParse,
+                TestName = "Brackets with noise and lagging text."
+            };
+
+            args.Add(YoggTreeTestHelper.ToObjArray(testArgs));
+
+            /************************************************************************************/
+
+            contentToParse = "test[ abc 123]test ";
+
+            child1 = new TestContextInstance(new TChild())
+            {
+                Contents = "[ abc 123]",
+                Depth = 1,
+                Tokens = new List<TestTokenInstance>()
+                {
+                    TestTokens.SparseOpenBracket<TChild>(),
+                    TestTokens.HorizontalWhitespace(" "),
+                    TestTokens.TextContent("abc"),
+                    TestTokens.HorizontalWhitespace(" "),
+                    TestTokens.TextContent("123"),
+                    TestTokens.SparseCloseBracketToken
+                }
+            };
+
+            expected = new TestContextInstance(new T())
+            {
+                Contents = contentToParse,
+                Depth = 0,
+                Tokens = new List<TestTokenInstance>()
+                {
+                    TestTokens.TextContent("test"),
+                    TestTokens.ChildContext("[ abc 123]", child1),
+                    TestTokens.TextContent("test "),
+                },
+                ChildContexts = new List<TestContextInstance> { child1 }
+            };
+
+            testArgs = new TestParseArgs<T>()
+            {
+                Expected = expected,
+                ContentToParse = contentToParse,
+                TestName = "Brackets with noise, leading and lagging text."
+            };
+
+            args.Add(YoggTreeTestHelper.ToObjArray(testArgs));
+        }
+    }
+}

--- a/YoggTree/YoggTree/Core/Spools/TokenSpool.cs
+++ b/YoggTree/YoggTree/Core/Spools/TokenSpool.cs
@@ -73,7 +73,6 @@ namespace YoggTree.Core.Spools
         internal static (SpooledResult Spool, int CurrentSpoolIndex) GetNextResult(this TokenSpool spool, int startIndex, ReadOnlyMemory<char> content)
         {
             SpooledResult lastResult = null;
-            int lastIndex = 0;
 
             if (startIndex >= spool.CurrentContentIndex) //if we're looking forwards down the spool, start looking at all the next results and find the one before the one that is after the start index.
             {
@@ -84,8 +83,6 @@ namespace YoggTree.Core.Spools
                 {
                     var curSpool = spool.ResultSpool[x];
                     if (curSpool == null) break;
-
-                    lastIndex = curSpool.StartIndex + curSpool.Length;
 
                     lastResult = curSpool;
                     if (curSpool.IsEmpty() == false && curSpool.IsAfter(startIndex) == true)
@@ -131,15 +128,9 @@ namespace YoggTree.Core.Spools
                 }                
             }
 
-            if (lastIndex < startIndex && lastResult.IsEmpty()) //we didn't find anything after the starting index, we're done
-            {
-                spool.EndOfContent = true;
-                return (null, -1);
-            }
+            int newStartIndex = lastResult.IsEmpty() == true ? 0 : lastResult.StartIndex + lastResult.Length; //we restart the spool AFTER the last usable result so we don't re-spool old results. This should only resolve to 0 on the first attempt to use the spool.
 
-            startIndex = lastResult.IsEmpty() == true ? 0 : lastResult.StartIndex + lastResult.Length; //we restart the spool AFTER the last usable result so we don't re-spool old results. This should only resolve to 0 on the first attempt to use the spool.
-
-            spool.FillSpool(startIndex, content); //refill the spool from the new index
+            spool.FillSpool(newStartIndex, content); //refill the spool from the new index
             spool.CurrentSpoolIndex = 0;
             spool.CurrentContentIndex = startIndex;
 


### PR DESCRIPTION
Fix was to do all token math using the absolute index of the content in the ParseSession's content rather than in the relative index of the tokens.